### PR TITLE
空のレターペア表を登録しようとした時にエラーを表示

### DIFF
--- a/src/js/letterPairTable.js
+++ b/src/js/letterPairTable.js
@@ -101,6 +101,13 @@ const saveLetterPairTable = (hot) => {
         },
     };
 
+    if (letterPairTable.length === 0) {
+        alert('何か単語を登録してください。');
+        saveBtn.disabled = false;
+        hot.readonly = false;
+        return;
+    }
+
     rp(options)
         .then((result) => {
             alert('保存が完了しました');


### PR DESCRIPTION
レターペア表の配列を空にしてAPIに渡すと、APIはundefinedとして受け取る(Expressまたはbody-parserの仕様?)

「undefinedを受け取った時に、letterPairを全消去」とするとレターペア表を渡し忘れた時のような誤ったリクエストと区別ができないので、安全側に倒して空のレターペア表は登録できないようにした。

Fixes #20 