### PR TITLE
handsontable 2.0.0に対応: スマートフォン・タブレットから表を編集可能になった

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4037,9 +4037,9 @@
       "dev": true
     },
     "handsontable": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-0.37.0.tgz",
-      "integrity": "sha512-rrnxZzOfyvM/f2mfCv1M1Zrj5pUAHnkK7Wdiu4PltI0XvAP1pI260Euh7U1ZikUw0cLwl1Xhd0aoUBgkCBR8VQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/handsontable/-/handsontable-2.0.0.tgz",
+      "integrity": "sha512-o8yCOgyV0LkBrEyMrGtfex4UDJ+Pw3+Eeoxk9rRg2LmlziJsgwGlz5e4W1YP3/Ew7bPW/iyGlL4q1bp+6pcD/g==",
       "requires": {
         "moment": "2.20.1",
         "numbro": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "chunk": "0.0.2",
-    "handsontable": "~0.37",
+    "handsontable": "^2.0.0",
     "mathjs": "^4.1.1",
     "net": "1.0.2",
     "request": "^2.85.0",


### PR DESCRIPTION
Fixed #6
handsontableのアップデートにより、特に苦労せずに解決。 (ただし、時間はかかった)