### PR TITLE
Bugfix: レターペアクイズで1未満の日数を指定された時には1にするように修正

### DIFF
--- a/src/js/letterPairQuiz.js
+++ b/src/js/letterPairQuiz.js
@@ -113,7 +113,12 @@ const submit = (selectedLetterPairs, isRecalled) => {
 const reloadWithOptions = () => {
     const daysText = document.querySelector('.settingForm__daysText');
 
-    const days = parseInt(daysText.value);
+    // daysは1以上の値であることを想定
+    let days = parseInt(daysText.value);
+    if (days < 1) {
+        days = 1;
+    }
+
     const solved = document.querySelector('#settingForm__radio--solved').checked;
 
     location.href = `${config.urlRoot}/letterPairQuiz.html?&solved=${solved}&days=${days}`;


### PR DESCRIPTION
以前は1未満の値を許容してしまっていた。現在から過去に遡る日数であるため、1未満はNG