### PR TITLE
Bugfix: 3-styleの登録時に、同じパーツのステッカーが入力されていたらエラーにする

### DIFF
--- a/src/js/registerThreeStyleCorner.js
+++ b/src/js/registerThreeStyleCorner.js
@@ -1,6 +1,7 @@
 const rp = require('request-promise');
 const url = require('url');
 const config = require('./config');
+const utils = require('./utils');
 
 // FIXME テスト書く
 const isValidMoves = (moveStr) => {
@@ -122,6 +123,11 @@ const saveThreeStyleCorner = () => {
             const buffer = stickers[0];
             const sticker1 = stickers[1];
             const sticker2 = stickers[2];
+
+            if (utils.isInSameParts(buffer, sticker1) || utils.isInSameParts(sticker1, sticker2) || utils.isInSameParts(sticker2, buffer)) {
+                alert('同じパーツのステッカーが入力されています');
+                return;
+            }
 
             const threeStyleOptions = {
                 url: `${config.apiRoot}/threeStyle/corner`,

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -43,6 +43,13 @@ const strMin = (s1, s2) => {
     return s2;
 };
 
+// 2つのステッカーが、同じパーツに属するかを判定
+const isInSameParts = (sticker1, sticker2) => {
+    const s1 = Array.from(sticker1).sort().join('');
+    const s2 = Array.from(sticker2).sort().join('');
+    return s1 === s2;
+};
+
 // n個グループにして、そのグループ内で順番を入れ替える
 const chunkAndShuffle = (arr, n) => {
     const grouped = chunk(arr, n).map(arr => shuffle(arr, { copy: true, }));
@@ -54,4 +61,5 @@ exports.edges = edges;
 exports.showMove = showMove;
 exports.strMax = strMax;
 exports.strMin = strMin;
+exports.isInSameParts = isInSameParts;
 exports.chunkAndShuffle = chunkAndShuffle;

--- a/test/utils.js
+++ b/test/utils.js
@@ -55,4 +55,16 @@ describe('utils.js', () => {
             assert.deepEqual(actual, expected);
         });
     });
+
+    describe('isInSameParts()', () => {
+        it('正常系: True', () => {
+            const actual = utils.isInSameParts('UBL', 'BLU');
+            assert.deepEqual(actual, true);
+        });
+
+        it('正常系: False', () => {
+            const actual = utils.isInSameParts('UBL', 'FDR');
+            assert.deepEqual(actual, false);
+        });
+    });
 });


### PR DESCRIPTION
これまでは`UBL UFR RFU`のような組を許容してしまっていた。

Fixed #171 