### PR TITLE
【WIP】Security: hoekを5.0.3以上に上げる。

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chunk": "0.0.2",
     "count-array-values": "^1.2.1",
     "handsontable": "^2.0.0",
+    "hoek": "^5.0.3",
     "mathjs": "^4.1.2",
     "net": "1.0.2",
     "request": "^2.85.0",


### PR DESCRIPTION
現在では、依存の依存として入っていて、しかも親が4.x.xを指定しているので実現できていない。
忘れないように、PRとして残しておく。

Fixed #167 