### PR TITLE
Bugfix: レターペアクイズや3-styleクイズの結果の保存時には、正解・不正解に応じた秒数の変換は行わないように修正。

### DIFF
--- a/src/js/letterPairQuiz.js
+++ b/src/js/letterPairQuiz.js
@@ -67,10 +67,6 @@ const submit = (selectedLetterPairs, isRecalled) => {
     if (sec < 0.25) {
         return;
     }
-    let sendSec = 60.0;
-    if (isRecalled === 1) {
-        sendSec = sec;
-    }
 
     const options = {
         url: `${config.apiRoot}/letterPairQuizLog`,
@@ -83,7 +79,7 @@ const submit = (selectedLetterPairs, isRecalled) => {
             letters,
             isRecalled,
             token,
-            sec: sendSec,
+            sec,
         },
     };
 

--- a/src/js/threeStyleQuizCorner.js
+++ b/src/js/threeStyleQuizCorner.js
@@ -97,10 +97,7 @@ const submit = (letterPairs, numberings, selectedThreeStyles, isRecalled) => {
         return;
     }
 
-    let sendSec = 20; // 間違えた場合は一律20秒
-    if (isRecalled === 1) {
-        sendSec = sec / 3.0; // 1回ぶん回すタイムに換算
-    }
+    const sendSec = sec / 3.0; // 1回ぶん回すタイムに換算
 
     const options = {
         url: `${config.apiRoot}/threeStyleQuizLog/corner`,


### PR DESCRIPTION
Fixed #68 