### PR TITLE
3-style手順表のページタイトルで「コーナー」がベタ打ちされていたので修正

### DIFF
--- a/src/html/threeStyle/table.html
+++ b/src/html/threeStyle/table.html
@@ -17,7 +17,7 @@
       }
     </script>
 
-    <title>3-style Corner表</title>
+    <title>3-style手順表</title>
     <meta charset="UTF-8">
     <meta name="robots" content="noindex,nofollow,noarchive">
     <meta http-equiv="pragma" content="no-store">


### PR DESCRIPTION
Fixed #482 