### PR TITLE
Bugfix: 表でセルを削除したときにエラーが起こるのを修正

### DIFF
--- a/src/js/letterPairTable.js
+++ b/src/js/letterPairTable.js
@@ -66,7 +66,10 @@ const saveLetterPairTableFromHot = (hot) => {
     for (let r = 1; r < rowLn; r++) {
         for (let c = 1; c < colLn; c++) {
             const letters = col0[r] + row0[c];
-            const cellStr = hot.getDataAtCell(r, c);
+
+            // バックスペースだけ押してセルを削除し、すぐに表の外にフォーカスを移した場合は
+            // cellStrはnullになる
+            const cellStr = hot.getDataAtCell(r, c) || '';
 
             const words = cellStr === '' ? [] : cellStr.replace(/\s/g, '').split(/[,，、/／]/).filter(x => x.length > 0);
 

--- a/src/js/threeStyleTable.js
+++ b/src/js/threeStyleTable.js
@@ -131,7 +131,9 @@ const saveThreeStyleTable = (hot, part, numbering) => {
             const letter2 = sticker2Match[1]; // 'き' など
             const sticker2 = sticker2Match[2]; // 'RDF' など
 
-            const cellStr = hot.getDataAtCell(r, c);
+            // バックスペースだけ押してセルを削除し、すぐに表の外にフォーカスを移した場合は
+            // cellStrはnullになる
+            const cellStr = hot.getDataAtCell(r, c) || '';
             let threeStyles = [];
             try {
                 threeStyles = utils.readThreeStyles(cellStr);


### PR DESCRIPTION
うえしゅうさんからの報告。

レターペア表や3-style表で、特定のセルを選択後にバックスペースだけ押してセルを削除し、すぐに表の外にフォーカスを移した場合はセルの値は空文字ではなく`null`になるため、直後の処理でnullにたいして`.replace()`を使おうとしてエラーとなっていた。

nullガードを加えることで解決。