### PR TITLE
トランプ記憶で、記憶の方向が右から左の時に画面が固まる不具合を修正

### DIFF
--- a/src/js/components/organisms/MemoTrainingCardsRecall/index.js
+++ b/src/js/components/organisms/MemoTrainingCardsRecall/index.js
@@ -76,7 +76,8 @@ const MemoTrainingCardsRecall = ({
                         });
                     });
 
-                    const flatten = isLefty ? _.flattenDeep(components) : _.reverse(_.cloneDeep(_.flattenDeep(components)));
+                    // _.reverse()は破壊的なメソッドだが、_.flattenDeep()によって新しい配列が生成されているので、その新しい配列が破壊されても問題ない
+                    const flatten = isLefty ? _.flattenDeep(components) : _.reverse(_.flattenDeep(components));
 
                     const chunkSize = 12;
                     return _.chunk(flatten, chunkSize).map((bulk, bulkInd) => {


### PR DESCRIPTION
くるくるキャプテンさんからの報告。

トランプ記憶で右から左に覚えていくオプションをつけた時に、表示向きをindの降順にするために以下のようにオブジェクトを生成していた
```
_.reverse(_.cloneDeep(_.flattenDeep(components)));
```
これは `_.reverse()` が破壊的メソッドなので破壊される前にコピーしておくという意図だったが、`_.flattenDeep()`によって新しい配列が生成されているので、その新しい配列が破壊されても問題ない
