### PR TITLE
数字記憶で、空欄がある状態でリコール完了するとエラーになるのを修正

### DIFF
--- a/src/js/memoTrainingUtils.js
+++ b/src/js/memoTrainingUtils.js
@@ -602,13 +602,16 @@ export const splitNumbersImageInDecks = (decks, digitsPerImage, pairSize) => {
 
 export const mergeNumbersImageInDecks = (decks, digitsPerImage, pairSize) => {
     return decks.map(deck => {
-        const deckStr = deck.map(pair => {
-            return pair.map(element => {
-                return element.tag;
-            }).join('');
-        }).join('');
-
-        return generateNumbersDeck(deckStr, digitsPerImage, pairSize);
+        return deck.map(pair => {
+            return _.chunk(pair, digitsPerImage).map(digitsInImage => {
+                if (digitsInImage.includes(null)) {
+                    return null;
+                } else {
+                    const tag = digitsInImage.map(element => element.tag).join('');
+                    return new NumberElement(tag);
+                }
+            });
+        });
     });
 };
 
@@ -616,7 +619,12 @@ export const mergeLastRecallMiliUnixtimePairsList = (lastRecallMiliUnixtimePairs
     return lastRecallMiliUnixtimePairsList.map(deck => {
         return deck.map(pair => {
             return _.chunk(pair, digitsPerImage).map(digitsInImage => {
-                return _.max(digitsInImage);
+                const tmpMax = _.max(digitsInImage);
+
+                // digitsInImageの要素が全てnullの場合は、値がundefinedになる
+                // この場合に、nullに直す。
+                // 配列中の不明値はundefinedではなくnullとする想定でコーディングしている
+                return tmpMax || null;
             });
         });
     });

--- a/src/js/modules/memoTraining.js
+++ b/src/js/modules/memoTraining.js
@@ -856,6 +856,22 @@ export const memoTrainingReducer = handleActions(
             };
         },
         [startMemorizationPhase]: (state, action) => {
+            const decks = action.payload.decks;
+
+            // decksと構造が一致することを保証するために、lastMemoMiliUnixtimePairsListをnullで埋めて初期化
+            const lastMemoMiliUnixtimePairsList = [ [], ];
+            for (let deckInd = 0; deckInd < decks.length; deckInd++) {
+                const pairs = decks[deckInd];
+                lastMemoMiliUnixtimePairsList[deckInd] = [];
+                for (let pairInd = 0; pairInd < pairs.length; pairInd++) {
+                    const pair = pairs[pairInd];
+                    lastMemoMiliUnixtimePairsList[deckInd][pairInd] = [];
+                    for (let posInd = 0; posInd < pair.length; posInd++) {
+                        lastMemoMiliUnixtimePairsList[deckInd][pairInd][posInd] = null;
+                    }
+                }
+            }
+
             if (typeof state.mode === 'undefined') {
                 return {
                     ...state,
@@ -867,11 +883,13 @@ export const memoTrainingReducer = handleActions(
                     memoEvent: action.payload.memoEvent,
                     deckSize: action.payload.deckSize,
                     digitsPerImage: action.payload.digitsPerImage,
-                    decks: action.payload.decks,
+                    decks,
                     startMemoMiliUnixtime: action.payload.currentMiliUnixtime,
                     mode: action.payload.mode,
                     phase: memoTrainingUtils.TrainingPhase.memorization,
                     elementIdsDict: action.payload.elementIdsDict,
+
+                    lastMemoMiliUnixtimePairsList,
                 };
             }
 
@@ -909,6 +927,24 @@ export const memoTrainingReducer = handleActions(
                 newLastMemoMiliUnixtimePairsList[deckInd][pairInd][posInd] = currentMiliUnixtime;
             }
 
+            // newDecksと構造が一致することを保証するために、solutionとlastRecallMiliUnixtimePairsListをnullで埋めて初期化
+            const solution = [ [], ];
+            const lastRecallMiliUnixtimePairsList = [ [], ];
+            for (let deckInd = 0; deckInd < newDecks.length; deckInd++) {
+                const pairs = newDecks[deckInd];
+                solution[deckInd] = [];
+                lastRecallMiliUnixtimePairsList[deckInd] = [];
+                for (let pairInd = 0; pairInd < pairs.length; pairInd++) {
+                    const pair = pairs[pairInd];
+                    solution[deckInd][pairInd] = [];
+                    lastRecallMiliUnixtimePairsList[deckInd][pairInd] = [];
+                    for (let posInd = 0; posInd < pair.length; posInd++) {
+                        solution[deckInd][pairInd][posInd] = null;
+                        lastRecallMiliUnixtimePairsList[deckInd][pairInd][posInd] = null;
+                    }
+                }
+            }
+
             if (state.mode === memoTrainingUtils.TrainingMode.transformation) {
                 return {
                     ...initialState,
@@ -929,7 +965,9 @@ export const memoTrainingReducer = handleActions(
                     decks: newDecks, // デッキは変換後を使う
                     deckInd: 0,
                     pairInd: 0,
+                    solution,
                     lastMemoMiliUnixtimePairsList: newLastMemoMiliUnixtimePairsList,
+                    lastRecallMiliUnixtimePairsList,
                 };
             } else {
                 throw new Error(`unexpected mode : ${state.mode}`);

--- a/test/memoTrainingUtils.js
+++ b/test/memoTrainingUtils.js
@@ -499,9 +499,72 @@ describe('memoTrainingUtils.js', () => {
 
             assert.deepStrictEqual(actual, expected);
         });
+
+        it('正常系: solutionをマージする際、解答していないholeがあってnullの場合 (解答していない部分は全てnullになっている想定)', () => {
+            const oneImageDecks = [
+                [
+                    [
+                        new memoTrainingUtils.NumberElement('1'),
+                        new memoTrainingUtils.NumberElement('2'),
+                        new memoTrainingUtils.NumberElement('3'),
+                        new memoTrainingUtils.NumberElement('4'),
+                        null,
+                        null,
+                    ],
+                    [
+                        new memoTrainingUtils.NumberElement('7'),
+                    ],
+                ],
+
+                [
+                    [
+                        new memoTrainingUtils.NumberElement('8'),
+                        null,
+                        new memoTrainingUtils.NumberElement('9'),
+                        new memoTrainingUtils.NumberElement('0'),
+                        new memoTrainingUtils.NumberElement('9'),
+                        new memoTrainingUtils.NumberElement('1'),
+                    ],
+                    [
+                        new memoTrainingUtils.NumberElement('2'),
+                    ],
+                ],
+            ];
+
+            const digitsPerImage = 2;
+            const pairSize = 3;
+
+            const actual = memoTrainingUtils.mergeNumbersImageInDecks(oneImageDecks, digitsPerImage, pairSize);
+
+            const expected = [
+                [
+                    [
+                        new memoTrainingUtils.NumberElement('12'),
+                        new memoTrainingUtils.NumberElement('34'),
+                        null,
+                    ],
+                    [
+                        new memoTrainingUtils.NumberElement('7'),
+                    ],
+                ],
+
+                [
+                    [
+                        null,
+                        new memoTrainingUtils.NumberElement('90'),
+                        new memoTrainingUtils.NumberElement('91'),
+                    ],
+                    [
+                        new memoTrainingUtils.NumberElement('2'),
+                    ],
+                ],
+            ];
+
+            assert.deepStrictEqual(actual, expected);
+        });
     });
 
-    describe('mergeNumbersImageInDecks()', () => {
+    describe('mergeLastRecallMiliUnixtimePairsList()', () => {
         it('正常系', () => {
             const digitsPerImage = 3;
 
@@ -529,6 +592,71 @@ describe('memoTrainingUtils.js', () => {
                     [ 19, ],
                 ],
 
+            ];
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('正常系: nullを含む', () => {
+            const digitsPerImage = 3;
+
+            const lastRecallMiliUnixtimePairsList = [
+                [
+                    [ 1, 2, null, 4, 5, 6, ],
+                    [ 7, 8, 9, ],
+                ],
+
+                [
+                    [ null, null, null, 14, null, null, ],
+                    [ 17, 18, 19, ],
+                ],
+            ];
+
+            const actual = memoTrainingUtils.mergeLastRecallMiliUnixtimePairsList(lastRecallMiliUnixtimePairsList, digitsPerImage);
+            const expected = [
+                [
+                    [ 2, 6, ],
+                    [ 9, ],
+                ],
+
+                [
+                    [ null, 14, ],
+                    [ 19, ],
+                ],
+
+            ];
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it.skip('正常系: nullで抜けていたり、飛ばされていたりする場合: このテストは通らないが、実際に利用する際にこのような引数を渡さないことでカバーしてある。', () => {
+            const digitsPerImage = 3;
+            // const pairSize = 2;
+            // const deckSize = 9; // イメージ数ではなく桁数
+
+            const lastRecallMiliUnixtimePairsList = [
+                [
+                    [ 1, 2, null, 4, 5, ],
+                    [ 7, 8, 9, ], // これは最後
+                ],
+
+                [
+                    [ 11, 12, ],
+                    [ 17, 18, ],
+                ],
+            ];
+
+            const actual = memoTrainingUtils.mergeLastRecallMiliUnixtimePairsList(lastRecallMiliUnixtimePairsList, digitsPerImage);
+            const expected = [
+                [
+                    [ 2, 5, ],
+                    [ 9, ], // これは最後
+                ],
+
+                [
+                    [ 12, null, ],
+                    [ 18, ],
+                ],
             ];
 
             assert.deepStrictEqual(actual, expected);


### PR DESCRIPTION
数字記憶で、空欄がある状態でリコール完了すると`null`があり、結合する際に`null.tag`をしようとしてエラーになるのを修正