### PR TITLE
MBLD練習の一度に表示する単語数を4までにした

### DIFF
--- a/src/js/components/organisms/MemoTrainingMbldSetting/index.js
+++ b/src/js/components/organisms/MemoTrainingMbldSetting/index.js
@@ -14,7 +14,7 @@ const path = require('path');
 const urlRoot = path.basename(config.urlRoot);
 
 const deckNumOptions = [ ...Array(50).keys(), ].map(ind => [ String(ind + 1), String(ind + 1), ]);
-const pairSizeList = [ ...Array(16).keys(), ].map(ind => [ String(ind + 1), `${ind + 1}単語`, ]);
+const pairSizeList = [ ...Array(4).keys(), ].map(ind => [ String(ind + 1), `${ind + 1}単語`, ]);
 
 const MemoTrainingMbldSetting = ({
     deckNum,


### PR DESCRIPTION
MBLD練習で一度に表示させたい単語数がパート内の単語数を超える場合にエラーが起こるので、いったんそのような状況が発生しないようにした