### PR TITLE
3-styleインポート機能で、因数分解していない手順がエラーになってしまっていたのを修正

### DIFF
--- a/src/js/importThreeStyle.js
+++ b/src/js/importThreeStyle.js
@@ -11,16 +11,16 @@ const utils = require('./utils');
 const detectStickers = (part, bufferSticker, setup, move1, move2) => {
     try {
         if (part === constant.partType.corner) {
-            const alg = Algorithm333.makeThreeStyle(setup, move1, move2);
+            const alg = (move1 === '' && move2 === '') ? new Algorithm333(setup) : Algorithm333.makeThreeStyle(setup, move1, move2);
             return alg.detectThreeStyleCornerStickers(bufferSticker);
         } else if (part === constant.partType.edgeMiddle) {
-            const alg = Algorithm333.makeThreeStyle(setup, move1, move2);
+            const alg = (move1 === '' && move2 === '') ? new Algorithm333(setup) : Algorithm333.makeThreeStyle(setup, move1, move2);
             return alg.detectThreeStyleEdgeStickers(bufferSticker);
         } else if (part === constant.partType.edgeWing) {
-            const alg = Algorithm444.makeThreeStyle(setup, move1, move2);
+            const alg = (move1 === '' && move2 === '') ? new Algorithm444(setup) : Algorithm444.makeThreeStyle(setup, move1, move2);
             return alg.detectThreeStyleWingEdgeStickers(bufferSticker);
         } else if (part === constant.partType.centerX) {
-            const alg = Algorithm444.makeThreeStyle(setup, move1, move2);
+            const alg = (move1 === '' && move2 === '') ? new Algorithm444(setup) : Algorithm444.makeThreeStyle(setup, move1, move2);
             return alg.detectThreeStyleXCenterStickers(bufferSticker);
         } else if (part === constant.partType.centerT) {
             // throw new Error(`Unexpected part : ${JSON.stringify(part)}`);


### PR DESCRIPTION
原因: hinemos上で因数分解していない手順は move1='', move2='' として扱っているが、それを考慮せずに `makeThreeStyle` してしまったため、 `setup move1 move2 move1' move2' setup'` とした結果、空の回転になってしまっていた。