### PR TITLE
3-style問題リスト詳細画面で、解いていない問題については正解率とtpsを0.00にする

### DIFF
--- a/src/js/modules/threeStyleProblemListDetail.js
+++ b/src/js/modules/threeStyleProblemListDetail.js
@@ -145,9 +145,9 @@ function * handleLoadInitially () {
                 }
 
                 const na = 'N/A';
-                const dispAcc = acc === null ? na : acc.toFixed(2);
+                const dispAcc = acc === null ? (0).toFixed(2) : acc.toFixed(2);
                 const dispAvgSec = avgSec ? parseFloat(avgSec.toFixed(2)) : na;
-                const dispTps = tps === null ? na : parseFloat(tps.toFixed(2));
+                const dispTps = tps === null ? (0).toFixed(2) : tps.toFixed(2);
 
                 const record = {
                     ...detail,


### PR DESCRIPTION
sortable-tableの仕様で、数値ではない文字列(`N/A`)があると正しくソートがされないので、正解率とtpsについては`N/A`を使わないようにした。
タイムについては「0」のような都合の良い値が無いし、まだ解いていない問題だけフィルタリングしたいという目的があるので`N/A`のままにしてある。