### PR TITLE
3-style Scramblerで、複数問題リストが選択できるようにした

### DIFF
--- a/src/html/threeStyle/scrambler.html
+++ b/src/html/threeStyle/scrambler.html
@@ -72,20 +72,20 @@
          <tr>
            <td>コーナー</td>
            <td><select class="scrambleTypeSelect--corner">
-               <option value="threeStyle">3-style (登録済全て)</option>
-               <option value="threeStyleList">3-style (問題リスト)</option>
-               <option value="random">ランダム</option>
                <option value="none">崩さない</option>
+               <option value="random">ランダム</option>
+               <option value="threeStyle">3-style (登録済全て)</option>
+               <option value="threeStyleList">3-style (旧問題リスト)</option>
            </select></td>
          </tr>
 
          <tr>
            <td>エッジ</td>
            <td><select class="scrambleTypeSelect--edgeMiddle">
-               <option value="threeStyle">3-style (登録済全て)</option>
-               <option value="threeStyleList">3-style (問題リスト)</option>
-               <option value="random">ランダム</option>
                <option value="none">崩さない</option>
+               <option value="random">ランダム</option>
+               <option value="threeStyle">3-style (登録済全て)</option>
+               <option value="threeStyleList">3-style (旧問題リスト)</option>
            </select></td>
          </tr>
        </table>


### PR DESCRIPTION
Fixed #619 

* `<Select>`の要素として複数問題リストのリスト名を選択できるようにした
* それが選択された場合は、選択した問題リストがあたかも従来の唯一の問題リストであるかのように上書きしてから従来のロジックでスクランブルを行うようにした
