### PR TITLE
問題リスト詳細画面のソートをあいうえお順からtpsの昇順に変更

### DIFF
--- a/src/js/modules/threeStyleProblemListDetail.js
+++ b/src/js/modules/threeStyleProblemListDetail.js
@@ -183,14 +183,18 @@ function * handleLoadInitially () {
             });
         });
 
+        // tps順asc, タイムdesc, ナンバリングascでソートする
         // indの情報はレコードの数が確定してから追加する必要があるので最後にやっている
-        const detailsWithInd = threeStyleQuizProblemListDetail.map((rec, ind) => {
-            return {
-                ...rec,
-                ind,
-                pInd: ind + 1, // 1-origin (positive ind)
-            };
-        });
+        const detailsWithInd = _.orderBy(threeStyleQuizProblemListDetail,
+            [ 'dispTps', 'dispAvgSec', 'dispLetters', ],
+            [ 'asc', 'desc', 'asc', ])
+            .map((rec, ind) => {
+                return {
+                    ...rec,
+                    ind,
+                    pInd: ind + 1, // 1-origin (positive ind)
+                };
+            });
 
         const payload = {
             url,


### PR DESCRIPTION
速くなるためには遅い手順に注目することが重要だし、あいうえおはフィルターで絞り込むことができるので全体に散らばっていてもあまり問題ないと判断した。