### PR TITLE
3-styleの問題リスト自動作成で、似ている手順の木を作った後に幅優先ではなく深さ優先で辿るように変更した

### DIFF
--- a/src/js/modules/threeStyleProblemList.js
+++ b/src/js/modules/threeStyleProblemList.js
@@ -216,7 +216,7 @@ function * handleAutoCreateProblemLists () {
             return new threeStyleNavigatorUtils.Alg(arg, convertWideMove);
         });
 
-        const orderedAlgTuples = threeStyleNavigatorUtils.orderAlgsByEasiness(unOrderedAlgs);
+        const orderedAlgTuples = threeStyleNavigatorUtils.orderAlgsByEasinessDFS(unOrderedAlgs);
 
         const titles = orderedAlgTuples.map((tuple, i) => {
             const numStr = `${i + 1}`.padStart(3, '0');


### PR DESCRIPTION
3-styleの問題リスト自動作成で、似ている手順が固まっていたほうが覚える効率が上がりそうなので、似ている手順の木を作った後に幅優先ではなく深さ優先で辿るように変更した

BFSでのアルゴリズムを考えていた時はモールス符号のKoch法を土台に考えていたので似た手順を同時にやると混同しそうだと考えていたが、
モールス符号と違ってキューブの3-styleには理論があるので、今は似た手順は一度に学んだほうが覚える際の負荷が少ないと考えている。