### PR TITLE
3-styleインポートで、1つのセルに全ての情報が入っている場合にも読み込めるようにした

### DIFF
--- a/src/html/threeStyle/import.html
+++ b/src/html/threeStyle/import.html
@@ -73,6 +73,6 @@
       </div>
     </main>
 
-    <script type="text/javascript" src="../importThreeStyle.bundle.js?version=v1.11.1"></script>
+    <script type="text/javascript" src="../importThreeStyle.bundle.js?version=v1.14.1"></script>
   </body>
 </html>

--- a/src/js/importThreeStyle.js
+++ b/src/js/importThreeStyle.js
@@ -66,12 +66,28 @@ const importThreeStyleTable = (hot, part, bufferSticker, origThreeStyles) => {
             // バックスペースだけ押してセルを削除し、すぐに表の外にフォーカスを移した場合は
             // cellStrはnullになる
             const cellStr = hot.getDataAtCell(r, c) || '';
+            if (cellStr === '') {
+                continue;
+            }
 
             let threeStyles = [];
+
             try {
                 threeStyles = utils.readThreeStyles(cellStr, part);
             } catch (e) {
-                // ignore error
+                // 読み込めなかった場合は、1セルの中に複数のセルの情報が
+                // 収まっている可能性があるので、TABで分解する
+                const cells = cellStr.split('\t');
+
+                for (let i = 0; i < cells.length; i++) {
+                    const s = cells[i];
+                    try {
+                        const algs = utils.readThreeStyles(s, part);
+                        Array.prototype.push.apply(threeStyles, algs);
+                    } catch (e) {
+                        // ignore error
+                    }
+                }
             }
 
             // 空のセルに関してはpushしない


### PR DESCRIPTION
Ma29KHさんの問い合わせによるもの。
スマートフォンでスプレッドシートをコピーしてhinemosにコピーすると、全ての情報が1つのセルに収まってしまう。

この時、3-styleインポートができなかったので、1つのセルの中をタブで分割し、それぞれについてインポートを行うように修正した。