### PR TITLE
カラムの順番を変更

### DIFF
--- a/src/js/components/templates/MemoTrainingStatsTemplate/index.js
+++ b/src/js/components/templates/MemoTrainingStatsTemplate/index.js
@@ -112,8 +112,8 @@ const MemoTrainingStatsTemplate = (
                         '位置',
                         'element',
 
-                        '変換',
                         '記憶',
+                        '変換',
                         '(記憶-変換)',
 
                         '正解率',
@@ -126,8 +126,8 @@ const MemoTrainingStatsTemplate = (
                         'posInd',
                         'element',
 
-                        'transformation',
                         'memorization',
+                        'transformation',
                         'diff',
 
                         'acc',


### PR DESCRIPTION
`記憶`、`変換`、`記憶-順番`の順にした。

また、練習ページの方の開始ボタンの順番も`記憶`、`変換`の順なので整合性がある。