### PR TITLE
数字記憶のデフォルト桁数を80に変更

### DIFF
--- a/src/js/components/organisms/MemoTrainingNumbersSetting/index.js
+++ b/src/js/components/organisms/MemoTrainingNumbersSetting/index.js
@@ -56,7 +56,7 @@ const MemoTrainingNumbersSetting = ({
             <div>
             挑戦する束数: <Select options={deckNumOptions} defaultValue={deckNum || '1' } onChange={(e) => setDeckNum(parseInt(e.target.value))} />
                 <Br/>
-            1束あたりの桁数: <Select options={deckSizeOptions} defaultValue={deckSize || '100'} onChange={(e) => setDeckSize(parseInt(e.target.value))}/>
+            1束あたりの桁数: <Select options={deckSizeOptions} defaultValue={deckSize || '80'} onChange={(e) => setDeckSize(parseInt(e.target.value))}/>
                 <Br/>
             1イメージの桁数: <Select options={digitsPerImageOptions} defaultValue={digitsPerImage || '2'} onChange={(e) => setDigitsPerImage(parseInt(e.target.value))}/>
                 <Br/>

--- a/src/js/modules/memoTraining.js
+++ b/src/js/modules/memoTraining.js
@@ -200,7 +200,7 @@ function * handleStartMemorizationPhase () {
                 return 52;
             }
             if (memoEvent === memoTrainingUtils.MemoEvent.numbers) {
-                return 100;
+                return 80;
             }
             throw new Error('Unexpected event');
         })();


### PR DESCRIPTION
統計ページで、MemoryLeagueの上限である80桁の情報を表示するようにしたので、記憶練習のデフォルトも80桁に変更した。