### PR TITLE
記憶練習の試技結果と統計情報でMemory LeagueのScores Componentを表示

### DIFF
--- a/src/js/components/templates/MemoTrainingResultTemplate/index.js
+++ b/src/js/components/templates/MemoTrainingResultTemplate/index.js
@@ -86,11 +86,13 @@ const MemoTrainingResultTemplate = (
 
                 (() => {
                     const MyData = scores.map(score => {
+                        const sc = memoTrainingUtils.calcScoresComponent(event, score.totalMemoSec, score.totalRecallSec, score.allDeckNum, score.successDeckNum, score.allElementNum);
                         return {
                             createdAt: moment(score.createdAt).format('YYYY-MM-DD HH:mm:ss'),
                             trialId: score.trialId,
                             totalMemoTime: formatTime(score.totalMemoSec),
                             totalRecallTime: formatTime(score.totalRecallSec),
+                            scoresComponent: sc === null ? '' : sc,
 
                             triedDecks: formatAcc(score.successDeckNum, score.triedDeckNum, score.triedDeckAcc),
                             allDecks: formatAcc(score.successDeckNum, score.allDeckNum, score.allDeckAcc),
@@ -104,6 +106,7 @@ const MemoTrainingResultTemplate = (
                         '日時',
                         '記憶時間',
                         '回答時間',
+                        'ML Scores Component',
 
                         '挑戦(束)',
                         '全体(束)',
@@ -117,6 +120,7 @@ const MemoTrainingResultTemplate = (
                         'createdAt',
                         'totalMemoTime',
                         'totalRecallTime',
+                        'scoresComponent',
 
                         'triedDecks',
                         'allDecks',

--- a/src/js/components/templates/MemoTrainingResultTemplate/index.js
+++ b/src/js/components/templates/MemoTrainingResultTemplate/index.js
@@ -47,8 +47,9 @@ const formatTime = (sec) => {
     const hour = String(Math.floor(sec / 3600.0)).padStart(2, '0');
     const minute = String(Math.floor((sec - 3600 * hour) / 60.0)).padStart(2, '0');
     const remainSec = String(Math.floor(sec - 3600 * hour - 60 * minute)).padStart(2, '0');
+    const remainSecDecimal = (sec - 3600 * hour - 60 * minute - remainSec).toFixed(2).split('.')[1];
 
-    return `${hour}:${minute}:${remainSec}`;
+    return `${hour}:${minute}:${remainSec}.${remainSecDecimal}`;
 };
 
 const MemoTrainingResultTemplate = (

--- a/src/js/components/templates/MemoTrainingStatsTemplate/index.js
+++ b/src/js/components/templates/MemoTrainingStatsTemplate/index.js
@@ -114,6 +114,7 @@ const MemoTrainingStatsTemplate = (
                             return {
                                 totalMemoSec: score.totalMemoSec,
                                 allElementAcc: score.allElementAcc,
+                                scoresComponent: memoTrainingUtils.calcScoresComponent(event, score.totalMemoSec, score.totalRecallSec, score.allDeckNum, score.successDeckNum, score.allElementNum),
                                 createdAt: score.createdAt.format('YYYY/MM/DD HH:mm'),
                             };
                         });
@@ -128,9 +129,83 @@ const MemoTrainingStatsTemplate = (
                             return score.allElementAcc !== 1;
                         });
 
+                    let recentBestScoresComponents = standardScores
+                        .filter(score => score.scoresComponent !== null)
+                        .map(score => {
+                            return {
+                                totalMemoSec: score.totalMemoSec,
+                                scoresComponent: score.scoresComponent,
+                                createdAt: score.createdAt,
+                            };
+                        });
+
+                    // タイムの昇順ソート
+                    const RECENT_TOP_CNT = 5;
+                    recentBestScoresComponents.sort((a, b) => a.totalMemoSec - b.totalMemoSec);
+                    recentBestScoresComponents = recentBestScoresComponents.slice(0, RECENT_TOP_CNT);
+
+                    while (recentBestScoresComponents.length < RECENT_TOP_CNT) {
+                        const rec = {
+                            totalMemoSec: 61.0 * 60,
+                            scoresComponent: Math.floor(5.0 * (60.0 - 61.0 * 60)),
+                            createdAt: '9999/12/31 23:59',
+                        };
+
+                        recentBestScoresComponents.push(rec);
+                    }
+
+                    const scoresComponentsSum = _.sum(recentBestScoresComponents.map(rec => rec.scoresComponent));
+
+                    const paddingStyle = {
+                        padding: '5px 10px',
+                    };
+
+                    const tableNode = (() => {
+                        if (event !== 'cards' && event !== 'numbers') {
+                            return (
+                                <div />
+                            );
+                        }
+
+                        return (
+                            <div>
+                                <Txt>Top 5 Scores Componentの合計: {scoresComponentsSum}</Txt>
+
+                                <table border="1">
+                                    <thead>
+                                        <tr>
+                                            <th style={paddingStyle} align="right">Time</th>
+                                            <th style={paddingStyle} align="right">Date</th>
+                                            <th style={paddingStyle} align="right">Scores Component</th>
+                                        </tr>
+                                    </thead>
+
+                                    <tbody>
+
+                                        {
+                                            recentBestScoresComponents.map((rec, key) => {
+                                                return (
+                                                    <tr key={key}>
+                                                        <td style={paddingStyle} align="right">{rec.totalMemoSec.toFixed(2)}s</td>
+                                                        <td style={paddingStyle} align="right">{rec.createdAt}</td>
+                                                        <td style={paddingStyle} align="right">{rec.scoresComponent}</td>
+                                                    </tr>
+                                                );
+                                            })
+                                        }
+                                    </tbody>
+                                </table>
+
+                            </div>
+                        );
+                    })();
+
                     return (
                         <div>
                             <Txt>成功率: {successfulTrials.length}/{successfulTrials.length + badTrials.length} = {(1.0 * successfulTrials.length / (successfulTrials.length + badTrials.length) * 100).toFixed(2)}%</Txt>
+
+                            {tableNode}
+
                             <ScatterChart
                                 width={400}
                                 height={400}

--- a/src/js/memoTrainingUtils.js
+++ b/src/js/memoTrainingUtils.js
@@ -876,3 +876,33 @@ export const transformStatsJSONtoArray = (statsJSON, event) => {
     }
     return stats;
 };
+
+// Sub60できない人も成長過程を可視化できるように、4分以内にパーフェクトを取った場合はMemoryLeagueと違ってScores Componentが負になることを認める
+// 種目や出題数が異なる場合はnullを返す
+export const calcScoresComponent = (event, totalMemoSec, totalRecallSec, allDeckNum, successDeckNum, allElementNum) => {
+    if (allDeckNum !== 1 || successDeckNum !== 1) {
+        return null;
+    }
+
+    // 変換練習の場合はtotalRecallSecがnull
+    if (!totalRecallSec || totalRecallSec > 240.0) {
+        return null;
+    }
+
+    // FIXME ここ、Cardsの1枚1イメージ、Numbersで2桁1イメージを前提としているので注意
+    if (!(event === MemoEvent.cards && allElementNum === 52) && !(event === MemoEvent.numbers && allElementNum === 40)) {
+        return null;
+    }
+
+    const scoreML = (() => {
+        if (event === MemoEvent.cards) {
+            return Math.floor(5.0 * (60.0 - totalMemoSec));
+        } else if (event === MemoEvent.numbers) {
+            return Math.floor(5.0 * (60.0 - totalMemoSec));
+        }
+
+        return null;
+    })();
+
+    return scoreML;
+};

--- a/test/memoTrainingUtils.js
+++ b/test/memoTrainingUtils.js
@@ -962,4 +962,41 @@ describe('memoTrainingUtils.js', () => {
             }
         });
     });
+
+    describe('calcScoresComponent()', () => {
+        it('正常系: Cards', () => {
+            const actual = memoTrainingUtils.calcScoresComponent('cards', 12.34, 230, 1, 1, 52);
+
+            // floor(5.0 * (60 - 12.34))
+            const expected = 238;
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('正常系: Numbers', () => {
+            const actual = memoTrainingUtils.calcScoresComponent('numbers', 12.34, 230, 1, 1, 40);
+
+            // floor(5.0 * (60 - 12.34))
+            const expected = 238;
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('正常系: 変換練習のscoresComponentはnull点', () => {
+            const actual = memoTrainingUtils.calcScoresComponent('numbers', 12.34, null, 1, 1, 40);
+
+            const expected = null;
+
+            assert.deepStrictEqual(actual, expected);
+        });
+
+        it('正常系: 60秒をオーバーしている場合は負の点数になる', () => {
+            const actual = memoTrainingUtils.calcScoresComponent('numbers', 68.9, 230, 1, 1, 40);
+
+            // floor(5.0 * (60 - 68.9))
+            const expected = -45;
+
+            assert.deepStrictEqual(actual, expected);
+        });
+    });
 });


### PR DESCRIPTION
記憶練習の試技結果と統計情報でMemory LeagueのScores Componentを表示するようにした。

ついでに、記憶結果で小数点2桁まで表示するように変更した。