### PR TITLE
問題リスト詳細の[削除]ボタンがまぎらわしいので削除

### DIFF
--- a/src/js/components/templates/ThreeStyleProblemListDetailTemplate/index.js
+++ b/src/js/components/templates/ThreeStyleProblemListDetailTemplate/index.js
@@ -206,7 +206,7 @@ const ThreeStyleProblemListDetailTemplate = (
                                 avgSec: record.dispAvgSec,
                                 tps: record.dispTps,
                                 createdAt: record.createdAt ? record.createdAt.format('YYYY/MM/DD HH:mm') : null,
-                                operation: '[削除]',
+                                // operation: '[削除]',
                             };
                         });
 
@@ -220,7 +220,7 @@ const ThreeStyleProblemListDetailTemplate = (
                             '平均タイム',
                             'tps',
                             '手順作成日時',
-                            '操作',
+                            // '操作',
                         ];
 
                         const col = [
@@ -233,7 +233,7 @@ const ThreeStyleProblemListDetailTemplate = (
                             'avgSec',
                             'tps',
                             'createdAt',
-                            'operation',
+                            // 'operation',
                         ];
 
                         return (<SortableTbl tblData={myData}


### PR DESCRIPTION
「手順をリストから削除する」ことと「手順そのものを削除する」ことのを区別が難しく、どのようなUIにしたらよいかが思い付いていない。

誤解を招いてしまい、問い合わせがたびたびあるので削除表記を削除する。