### PR TITLE
問い合わせ対応: レターペアの途中で空白を入れることを許容する

### DIFF
--- a/src/js/letterPairTable.js
+++ b/src/js/letterPairTable.js
@@ -73,7 +73,7 @@ const saveLetterPairTableFromHot = (hot) => {
             // cellStrはnullになる
             const cellStr = hot.getDataAtCell(r, c) || '';
 
-            const words = cellStr === '' ? [] : cellStr.replace(/\s/g, '').split(/[,，、/／]/).filter(x => x.length > 0);
+            const words = cellStr === '' ? [] : cellStr.replace(/\s+/g, ' ').split(/[,，、/／]/).map(x => x.trim()).filter(x => x.length > 0);
 
             if (words.length > 0) {
                 const letterPair = {


### PR DESCRIPTION
Fixed #858 
レターペアの途中に空白が入ることを許容する。
前後の空白はカットする。
連続する空白は1つにまとめる。